### PR TITLE
MTDSA-19738 - use the real mtd-identifier-lookup locally

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -156,14 +156,8 @@ microservice {
 
     mtd-id-lookup {
       host = localhost
-      port = 8343
+      port = 9769
     }
-
-    stubs {
-      host = localhost
-      port = 8343
-    }
-    # remove when find out how to remove stubs. Stubs currently needed for local environment.
 
     non-repudiation {
       host = localhost


### PR DESCRIPTION
- also remove redundant "stub" config