### PR TITLE
Fix Fraud Prevention Headers to return actual values and not empty strings

### DIFF
--- a/app/uk/gov/hmrc/selfassessmentassist/api/models/auth/UserDetails.scala
+++ b/app/uk/gov/hmrc/selfassessmentassist/api/models/auth/UserDetails.scala
@@ -25,8 +25,8 @@ case class UserDetails(userType: AffinityGroup, agentReferenceNumber: Option[Str
 
   val toCustomerType: CustomerType = userType match {
     case AffinityGroup.Individual | AffinityGroup.Organisation => CustomerType.TaxPayer
-    case AffinityGroup.Agent      => CustomerType.Agent
-    case _                        => throw new IllegalStateException(s"[UserDetails][toCustomerType] Invalid $userType")
+    case AffinityGroup.Agent                                   => CustomerType.Agent
+    case _                                                     => throw new IllegalStateException(s"[UserDetails][toCustomerType] Invalid $userType")
   }
 
 }

--- a/app/uk/gov/hmrc/selfassessmentassist/v1/controllers/GenerateReportController.scala
+++ b/app/uk/gov/hmrc/selfassessmentassist/v1/controllers/GenerateReportController.scala
@@ -79,7 +79,6 @@ class GenerateReportController @Inject() (
     logger.info(s"$correlationId::[generateReportInternal] Received request to generate an assessment report")
 
     authorisedAction(nino).async { implicit request =>
-
       val customerType        = request.userDetails.toCustomerType
       val submissionTimestamp = currentDateTime.getDateTime
       val responseData: EitherT[Future, ErrorWrapper, ResponseWrapper[AssessmentReportWrapper]] =

--- a/test/uk/gov/hmrc/selfassessmentassist/v1/services/EnrolmentsAuthServiceSpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentassist/v1/services/EnrolmentsAuthServiceSpec.scala
@@ -23,7 +23,12 @@ import uk.gov.hmrc.selfassessmentassist.v1.models.request.nrs.IdentityData
 import uk.gov.hmrc.auth.core.retrieve.{ItmpAddress, ItmpName}
 import uk.gov.hmrc.auth.core.syntax.retrieved._
 import play.api.libs.json.Json
-import uk.gov.hmrc.selfassessmentassist.v1.services.EnrolmentsAuthService.{authorisationDisabledPredicate, authorisationEnabledPredicate, mtdEnrolmentPredicate, supportingAgentAuthPredicate}
+import uk.gov.hmrc.selfassessmentassist.v1.services.EnrolmentsAuthService.{
+  authorisationDisabledPredicate,
+  authorisationEnabledPredicate,
+  mtdEnrolmentPredicate,
+  supportingAgentAuthPredicate
+}
 import uk.gov.hmrc.selfassessmentassist.support.{MockAppConfig, ServiceSpec}
 import uk.gov.hmrc.selfassessmentassist.config.ConfidenceLevelConfig
 import org.scalamock.handlers.CallHandler


### PR DESCRIPTION
I have added a [test branch ](https://github.com/hmrc/self-assessment-assist/tree/fix-fraud-prevention-headers-test) with this [commit](https://github.com/hmrc/self-assessment-assist/commit/b4357420234359fd419a19627a3032c816ffa77d) to test the changes. Using the code currently on main should fail and this fix should pass. Issue is toMap creates a case sensitive Map which makes it return all defaulted empty strings. Don't want to add the test for the headers in the repo.