### PR TITLE
Log error response bodies to investigate future failures

### DIFF
--- a/app/uk/gov/hmrc/selfassessmentassist/v1/connectors/IfsConnector.scala
+++ b/app/uk/gov/hmrc/selfassessmentassist/v1/connectors/IfsConnector.scala
@@ -59,7 +59,7 @@ class IfsConnector @Inject() (val httpClient: HttpClientV2, appConfig: AppConfig
             logger.info(s"$correlationId::[IfsConnector:submit]  ${ifRequest.eventName} interaction stored successfully")
             Right(IfsResponse())
           case unexpectedStatus @ _ =>
-            logger.error(s"$correlationId::[IfsConnector:submit]Unable to submit the report due to unexpected status code returned $unexpectedStatus")
+            logger.error(s"$correlationId::[IfsConnector:submit]Unable to submit the report due to unexpected status code returned $unexpectedStatus with body: ${response.body}")
             Left(ErrorWrapper(correlationId, InternalError))
         }
       }

--- a/app/uk/gov/hmrc/selfassessmentassist/v1/connectors/InsightConnector.scala
+++ b/app/uk/gov/hmrc/selfassessmentassist/v1/connectors/InsightConnector.scala
@@ -69,7 +69,7 @@ class InsightConnector @Inject() (val httpClient: HttpClientV2, appConfig: AppCo
                 report => Right(ResponseWrapper(correlationId, report))
               )
           case _ =>
-            logger.error(s"$correlationId::[InsightConnector:assess] CIP FraudRisk report failed as unknown code returned ${response.status}")
+            logger.error(s"$correlationId::[InsightConnector:assess] CIP FraudRisk report failed as unknown code returned ${response.status} with body: ${response.body}")
             Left(ErrorWrapper(correlationId, InternalError))
         }
       }

--- a/app/uk/gov/hmrc/selfassessmentassist/v1/connectors/NrsConnector.scala
+++ b/app/uk/gov/hmrc/selfassessmentassist/v1/connectors/NrsConnector.scala
@@ -72,7 +72,7 @@ class NrsConnector @Inject() (val httpClient: HttpClientV2, appConfig: AppConfig
             logger.info(s"$correlationId::[NrsConnector:submit] NRS submission successful status received from NRS $status")
             Right(nrsResponse)
           } else {
-            logger.warn(s"$correlationId::[NrsConnector:submit] NRS submission failed with error: $status")
+            logger.warn(s"$correlationId::[NrsConnector:submit] NRS submission failed with error: $status and body: ${response.body}")
             Left(NrsFailure.ErrorResponse(status))
           }
         }

--- a/app/uk/gov/hmrc/selfassessmentassist/v1/connectors/RdsConnector.scala
+++ b/app/uk/gov/hmrc/selfassessmentassist/v1/connectors/RdsConnector.scala
@@ -94,23 +94,23 @@ class RdsConnector @Inject() (val httpClient: HttpClientV2, appConfig: AppConfig
               )
 
           case BAD_REQUEST =>
-            logger.error(s"$correlationId::[RdsConnector:submit] RDS response : BAD request")
+            logger.error(s"$correlationId::[RdsConnector:submit] RDS response : BAD request with body: ${response.body}")
             Left(ErrorWrapper(correlationId, InternalError))
           case NOT_FOUND =>
-            logger.error(s"$correlationId::[RdsConnector:submit] RDS not reachable")
+            logger.error(s"$correlationId::[RdsConnector:submit] RDS not reachable with body: ${response.body}")
             Left(ErrorWrapper(correlationId, InternalError))
           case REQUEST_TIMEOUT =>
-            logger.error(s"$correlationId::[RdsConnector:submit] Rds request timeout")
+            logger.error(s"$correlationId::[RdsConnector:submit] Rds request timeout with body: ${response.body}")
             Left(ErrorWrapper(correlationId, InternalError))
           case UNAUTHORIZED =>
-            logger.error(s"$correlationId::[RdsConnector:submit] Rds request failed as unauthorized")
+            logger.error(s"$correlationId::[RdsConnector:submit] Rds request failed as unauthorized with body: ${response.body}")
             Left(ErrorWrapper(correlationId, ForbiddenDownstreamError))
           case SERVICE_UNAVAILABLE =>
-            logger.error(s"$correlationId::[RdsConnector:submit] Rds returned service unavailable")
+            logger.error(s"$correlationId::[RdsConnector:submit] Rds returned service unavailable with body: ${response.body}")
             Left(ErrorWrapper(correlationId, InternalError))
           case unexpectedStatus @ _ =>
             logger.error(
-              s"$correlationId::[RdsConnector:submit] Rds unable to submit the report due to unexpected status code returned $unexpectedStatus")
+              s"$correlationId::[RdsConnector:submit] Rds unable to submit the report due to unexpected status code returned $unexpectedStatus with body: ${response.body}")
             Left(ErrorWrapper(correlationId, InternalError))
         }
       }
@@ -189,16 +189,16 @@ class RdsConnector @Inject() (val httpClient: HttpClientV2, appConfig: AppConfig
                   }
               )
           case BAD_REQUEST =>
-            logger.error(s"$correlationId::[RdsConnector:acknowledgeRds] RDS response : BAD request")
+            logger.error(s"$correlationId::[RdsConnector:acknowledgeRds] RDS response : BAD request with body: ${response.body}")
             Left(ErrorWrapper(correlationId, InternalError))
           case NOT_FOUND =>
-            logger.error(s"$correlationId::[RdsConnector:acknowledgeRds] RDS not reachable")
+            logger.error(s"$correlationId::[RdsConnector:acknowledgeRds] RDS not reachable with body: ${response.body}")
             Left(ErrorWrapper(correlationId, InternalError))
           case UNAUTHORIZED =>
-            logger.error(s"$correlationId::[RdsConnector:acknowledgeRds] Rds request failed as unauthorized")
+            logger.error(s"$correlationId::[RdsConnector:acknowledgeRds] Rds request failed as unauthorized with body: ${response.body}")
             Left(ErrorWrapper(correlationId, ForbiddenDownstreamError))
           case REQUEST_TIMEOUT =>
-            logger.error(s"$correlationId::[RdsConnector:acknowledgeRds] Rds request timeout")
+            logger.error(s"$correlationId::[RdsConnector:acknowledgeRds] Rds request timeout with body: ${response.body}")
             Left(ErrorWrapper(correlationId, InternalError))
           case _ => Left(ErrorWrapper(correlationId, InternalError))
         }


### PR DESCRIPTION
No body returned when Assist failed earlier. Successful calls are coming through but logging error bodies for easier investigation of future failures.